### PR TITLE
Shuffle button filters questions by category

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -20,14 +20,14 @@ class CategoriesController < ApplicationController
   def show
     reset_shuffle
     @category = Category.find(params[:id])
-    @questions = @category.questions
+    @questions = @category.all_questions
   end
 
   def shuffle
     @category = Category.find(params[:id])
     session[:shuffle_category] = true
     last_question_ids = session[:last_shuffled_question_ids] || []
-    random_question = @category.questions.where.not(id: last_question_ids).order("RANDOM()").first
+    random_question = @category.all_questions.where.not(id: last_question_ids).order("RANDOM()").first
     session[:last_shuffled_question_ids] ||= []
     session[:last_shuffled_question_ids] << random_question.id if random_question
     if random_question

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -10,4 +10,12 @@ class Category < ApplicationRecord
 
   # Ensure name is present
   validates :name, presence: true
+
+  def all_questions
+    Question.joins(:question_categories).where(question_categories: { category_id: all_subcategory_ids })
+  end
+
+  def all_subcategory_ids
+    [ id ] + subcategories.flat_map(&:all_subcategory_ids)
+  end
 end


### PR DESCRIPTION
The shuffle functionality now correctly filters questions based on the selected category, ensuring that only relevant questions are considered during the shuffle process. This change addresses the issue where the shuffle button did not filter by category.

Fixes #15